### PR TITLE
Lead Client error message fields to have an explicit visibility

### DIFF
--- a/Api/Client.php
+++ b/Api/Client.php
@@ -12,10 +12,26 @@ use Rezzza\MailChimpBundle\Connection\ConnectionInterface;
  */
 class Client extends \Mailchimp
 {
-
+    /** @var ConnectionInterface */
     protected $connection;
+
+    /** @var Request */
     protected $lastRequest;
+
+    /** @var Response */
     protected $lastResponse;
+
+    /**
+     * @var string
+     * @deprecated Prefer using Client::getLastErrorMessage()
+     */
+    public $errorMessage;
+
+    /**
+     * @var int
+     * @deprecated Prefer using Client::getLastErrorCode()
+     */
+    public $errorCode;
 
     /**
      * Constructor
@@ -112,4 +128,19 @@ class Client extends \Mailchimp
         return $this->lastResponse;
     }
 
+    /**
+     * @return string
+     */
+    public function getLastErrorMessage()
+    {
+        return $this->errorMessage;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLastErrorCode()
+    {
+        return $this->errorCode;
+    }
 }

--- a/Tests/Units/Api/Client.php
+++ b/Tests/Units/Api/Client.php
@@ -12,7 +12,7 @@ class Client extends \mageekguy\atoum\test
     const CUSTOMER_LIST_ID = 'db993d96da';
 
     private $customerEmail;
-    
+
     /**
      * Test batch-subscribe success
      */
@@ -27,8 +27,11 @@ class Client extends \mageekguy\atoum\test
      */
     public function testBatchSubscribeFail()
     {
-        $response = $this->getClient()->call('lists/batch-subscribe', array_merge($this->getBatchSubscribeParameters(), array('id' => 'victor_samuel_mackey')));
-        $this->array($response)->isNotEmpty()->hasKey('error');
+        $client = $this->getClient();
+        $response = $client->call('lists/batch-subscribe', array_merge($this->getBatchSubscribeParameters(), array('id' => 'victor_samuel_mackey')));
+        $this->array($response)->isNotEmpty()->hasKey('error')
+            ->integer($client->getLastErrorCode())->isEqualTo(200)
+            ->string($client->getLastErrorMessage())->isEqualTo('Invalid MailChimp List ID: victor_samuel_mackey');
     }
 
     /**
@@ -110,7 +113,7 @@ class Client extends \mageekguy\atoum\test
         if (is_null($this->customerEmail) === true) {
             $this->customerEmail = 'mika+mailchimptest'.time().'@verylastroom.com';
         }
-        
+
         return $this->customerEmail;
     }
 


### PR DESCRIPTION
`Client::errorMessage` and `Client::errorCode` were used as public but not declared