### PR TITLE
Lead Client `lists` field to have an explicit visibility

### DIFF
--- a/Api/Client.php
+++ b/Api/Client.php
@@ -34,6 +34,12 @@ class Client extends \Mailchimp
     public $errorCode;
 
     /**
+     * @var \Mailchimp_Lists
+     * @deprecated Prefer using Client::getMailChimpLists()
+     */
+    public $lists;
+
+    /**
      * Constructor
      *
      * @param string $apiKey
@@ -142,5 +148,15 @@ class Client extends \Mailchimp
     public function getLastErrorCode()
     {
         return $this->errorCode;
+    }
+
+    /**
+     * Allow to send email in batch
+     *
+     * @return \Mailchimp_Lists
+     */
+    public function getMailChimpLists()
+    {
+        return $this->lists;
     }
 }


### PR DESCRIPTION
`Client::lists` was used as public but not declared

It will also ease [MailChimpClient](https://github.com/rezzza/MailChimpBundle/blob/8936177aae2491f0db7da89c470e577d7b400743/Api/Client.php#L19-19)` mocking when using `mailchimp/mailchimp/Mailchimp_Lists`.